### PR TITLE
Improve upon the repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,16 @@
 root = true
 
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [*.{yaml,yml,yml.j2,yaml.j2}]
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true
-insert_final_newline = true
 charset = utf-8
 
 [*.{tf,tfvars}]
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true
-insert_final_newline = true
 charset = utf-8
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*.{yaml,yml,yml.j2,yaml.j2}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{tf,tfvars}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.tfstate
 *.tfstate.*
 
+# Ignore the HCL lock file
+*.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@ approvers:
   - Starefossen
   - Haavere
   - mtverraen
+  - tomberget
 reviewers:
   - StianHaugland1
-  - tomberget
   - kristeey

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - Starefossen
+  - Haavere
+  - mtverraen
+reviewers:
+  - StianHaugland1
+  - tomberget
+  - kristeey

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create a module in your Terraform repository, and pin a release (for example) li
 
 ```terraform
 module "cilium_network_policies" {
-  source = "https://github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
+  source = "github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
 
   default_cilium_network_policies_enabled = true
   namespace                               = "namespace"

--- a/README.md
+++ b/README.md
@@ -31,13 +31,41 @@ Create a module in your Terraform repository, and pin a release (for example) li
 module "cilium_network_policies" {
   source = "github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
 
-  default_cilium_network_policies_enabled = true
-  namespace                               = "namespace"
+  parameter(s) = value
 
 }
 ```
 
 And you should be off to the races :)
+
+### Create DNS visibility network policies
+
+You can create a DNS visibility network policy for individual namespaces, or for all namespaces in your Kubernetes cluster. If you set `enable_dns_visibility` to `true`, the deciding factor is whether or not the `dns_namespace` parameter is assigned any value.
+
+If `dns_namespace` is omitted, or set like `dns_namespace = ""`, a DNS visibility network policy will be created in all namespaces in your Kubernetes cluster.
+
+*Example, creating in all namespaces*
+
+```terraform
+...
+
+  enable_dns_visibility = true
+
+}
+```
+
+If `dns_namspace` is set, the network policy will only be created for the defined value.
+
+*Example, create for one or more namespaces*
+
+```terraform
+...
+
+  enable_dns_visibility = true
+  dns_namespace         = ["namespace1", "namespace2",]
+
+}
+```
 
 ## Module idiosyncrasies
 
@@ -64,8 +92,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_default_cilium_network_policies_enabled"></a> [default\_cilium\_network\_policies\_enabled](#input\_default\_cilium\_network\_policies\_enabled) | Define whether or not the Cilium network policies should be created. | `bool` | `false` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Name of the Kubernetes namespace to install the Cilium Network Policies in | `string` | n/a | yes |
+| <a name="input_enable_dns_visibility"></a> [enable\_dns\_visiblity](#input\_enable\_dns\_visibility) | Define whether or not the DNS visibility Cilium network policy should be created. | `bool` | `false` | no |
+| <a name="input_dns_namespace"></a> [dns\_namspace](#input\_dns\_namspace) | Name of the Kubernetes namespace(s) to install the Cilium Network Policies in | `list(string)` | `[]`] | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ And you should be off to the races :)
 
 ### Create DNS visibility network policies
 
-You can create a DNS visibility network policy for individual namespaces, or for all namespaces in your Kubernetes cluster. If you set `enable_dns_visibility` to `true`, the deciding factor is whether or not the `dns_namespace` parameter is assigned any value.
+You can create a DNS visibility network policy for individual namespaces, or for all namespaces in your Kubernetes cluster. If you set `enable_dns_visibility` to `true`, the deciding factor is whether or not the `dns_namespaces` parameter is assigned any value.
 
-If `dns_namespace` is omitted, or set like `dns_namespace = ""`, a DNS visibility network policy will be created in all namespaces in your Kubernetes cluster.
+If `dns_namespaces` is omitted, or set like `dns_namespaces = ""`, a DNS visibility network policy will be created in all namespaces in your Kubernetes cluster.
 
 *Example, creating in all namespaces*
 
@@ -62,7 +62,7 @@ If `dns_namspace` is set, the network policy will only be created for the define
 ...
 
   enable_dns_visibility = true
-  dns_namespace         = ["namespace1", "namespace2",]
+  dns_namespaces         = ["namespace1", "namespace2",]
 
 }
 ```
@@ -93,7 +93,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_dns_visibility"></a> [enable\_dns\_visibility](#input\_enable\_dns\_visibility) | Define whether or not the DNS visibility Cilium network policy should be created. | `bool` | `false` | no |
-| <a name="input_dns_namespace"></a> [dns\_namspace](#input\_dns\_namspace) | Name of the Kubernetes namespace(s) to install the Cilium Network Policies in | `list(string)` | `[]`] | yes |
+| <a name="input_dns_namespaces"></a> [dns\_namespaces](#input\_dns\_namespaces) | Name of the Kubernetes namespace(s) to install the Cilium Network Policies in | `list(string)` | `[]`] | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create a module in your Terraform repository, and pin a release (for example) li
 
 ```terraform
 module "cilium_network_policies" {
-  source = "git://github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
+  source = "https://github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
 
   default_cilium_network_policies_enabled = true
   namespace                               = "namespace"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ provider "kubernetes" {
 To upgrade from the *kubernetes_alpha* provider, to using the **Beta** channel of the *kubernetes* provider, you can follow the instructions as provided here:
 https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/alpha-manifest-migration-guide
 
+## How to use this module
+
+Create a module in your Terraform repository, and pin a release (for example) like this:
+
+```terraform
+module "cilium_network_policies" {
+  source = "git://github.com/evry-ace/tf-cilium-network-policies.git?ref=vX.Y.Z"
+
+  default_cilium_network_policies_enabled = true
+  namespace                               = "namespace"
+
+}
+```
+
+And you should be off to the races :)
+
 ## Module idiosyncrasies
 
 *None*

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_enable_dns_visibility"></a> [enable\_dns\_visiblity](#input\_enable\_dns\_visibility) | Define whether or not the DNS visibility Cilium network policy should be created. | `bool` | `false` | no |
+| <a name="input_enable_dns_visibility"></a> [enable\_dns\_visibility](#input\_enable\_dns\_visibility) | Define whether or not the DNS visibility Cilium network policy should be created. | `bool` | `false` | no |
 | <a name="input_dns_namespace"></a> [dns\_namspace](#input\_dns\_namspace) | Name of the Kubernetes namespace(s) to install the Cilium Network Policies in | `list(string)` | `[]`] | yes |
 
 ## Outputs

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,16 @@
+# Contributing guidelines
+
+## Be a contributor and submit your own code
+
+### Linting
+
+Please use `terraform fmt --recursive` before submitting code to be reviewed.
+
+### Contributing
+
+- Contribute and comment :)
+- Submit an issue describing your proposed change to the repository.
+- Clone, or fork, the repository, develop and test your code changes.
+- Proof-read yourself.
+- Submit a pull request.
+

--- a/contributing.md
+++ b/contributing.md
@@ -13,4 +13,3 @@ Please use `terraform fmt --recursive` before submitting code to be reviewed.
 - Clone, or fork, the repository, develop and test your code changes.
 - Proof-read yourself.
 - Submit a pull request.
-

--- a/dns_visibility.tf
+++ b/dns_visibility.tf
@@ -1,16 +1,14 @@
 data "kubernetes_all_namespaces" "all_namespaces" {}
 
 locals {
-  namespace = length(var.dns_namespace) == 0 ? data.kubernetes_all_namespaces.all_namespaces : var.dns_namespace
-
-  ns_map = zipmap(var.enable_dns_visibility ? ["true"] : ["false"], local.namespace)
+  namespaces = length(var.dns_namespaces) == 0 ? data.kubernetes_all_namespaces.all_namespaces.namespaces : var.dns_namespaces
 
 }
 
 resource "kubernetes_manifest" "dns_visibility" {
   for_each = {
-    for k, v in local.ns_map : k => v
-    if k == "true"
+    for k in local.namespaces : k => k
+    if var.enable_dns_visibility == true
   }
 
   manifest = {

--- a/dns_visibility.tf
+++ b/dns_visibility.tf
@@ -70,4 +70,3 @@ resource "kubernetes_manifest" "dns_visibility" {
     }
   }
 }
-

--- a/providers.tf
+++ b/providers.tf
@@ -8,4 +8,3 @@ terraform {
 
   required_version = ">= 0.13"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "enable_dns_visibility" {
   default     = false
 }
 
-variable "dns_namespace" {
+variable "dns_namespaces" {
   description = "The Kubernetes namespace(s) where the resource(s) will be created. If omitted, or set to empty, and enable_dns_visiblity is set to true, the policy will be created for all namespaces in the Kubernetes cluster."
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -9,4 +9,3 @@ variable "namespace" {
   description = "The Kubernetes namespace where the resource(s) will be created"
   type        = string
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,12 @@
 # Default variables
-variable "default_cilium_network_policies_enabled" {
-  description = "Define whether or not the Cilium Network Policies should be created."
+variable "enable_dns_visibility" {
+  description = "Define whether or not the Cilium Network Policies for DNS visibility should be created."
   type        = bool
   default     = false
 }
 
-variable "namespace" {
-  description = "The Kubernetes namespace where the resource(s) will be created"
-  type        = string
+variable "dns_namespace" {
+  description = "The Kubernetes namespace(s) where the resource(s) will be created. If omitted, or set to empty, and enable_dns_visiblity is set to true, the policy will be created for all namespaces in the Kubernetes cluster."
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
This became a rather large PR. 

It changes the behaviour from creating the current DNS visibility policy once per namespace supplied, to instead create one policy per item in the list of namespaces supplied, or if omitted - one per namespace that exist in the Kubernetes cluster.

Guidelines for contributing has been added, as well as a default editor config file.

Merging this PR should be followed by a new release.