### PR TITLE
Change match_expressions to matchExpressions

### DIFF
--- a/dns_visibility.tf
+++ b/dns_visibility.tf
@@ -66,7 +66,7 @@ resource "kubernetes_manifest" "dns_visibility" {
       endpointSelector = {
         matchLabels = {}
         /* make sure we can restrict egress */
-        match_expressions = {
+        matchExpressions = {
           key      = "networking/use-networkPolicies"
           operator = "NotIn"
           values   = "true"


### PR DESCRIPTION
The object `match_expressions` in `endpointSelector` must be named `matchExpressions` in order for terraform to be able to create the necessary objects.﻿
